### PR TITLE
Fix/you tube url wikipedia img url

### DIFF
--- a/api/enrich.js
+++ b/api/enrich.js
@@ -2,7 +2,8 @@
 //
 // The CSV already gives us albumName, artist, and genre (authoritative). The Claude
 // API reads the Wikipedia wikitext and fills only the remaining factual fields. The
-// cover image comes from Wikipedia; the YouTube link is a constructed search URL.
+// cover image comes from Wikipedia; the YouTube link is resolved to a real /watch URL
+// via the YouTube Data API (falling back to a search URL when no key is configured).
 
 const Anthropic = require('@anthropic-ai/sdk');
 
@@ -38,7 +39,7 @@ Return ONLY these fields, read from the article (especially the {{Infobox album}
 - label: the record label that released it.
 - bandMembers: the performing artist's members/personnel. For a solo artist, use a one-element array with the artist's name.
 - isBandTogether: true if the artist/band is still active today, false if disbanded, on indefinite hiatus, or the primary artist is deceased.
-- rollingStoneReview: the album's Rolling Stone rating expressed as that many asterisks, one of "*", "**", "***", "****", "*****". Look in the "Professional ratings" / {{Album ratings}} box for the Rolling Stone entry (e.g. "4/5 stars" -> "****"). If the article has NO Rolling Stone rating, return "*".
+- rollingStoneReview: the album's Rolling Stone rating expressed as that many asterisks, one of "*", "**", "***", "****", "*****". Look in the "Professional ratings" / {{Album ratings}} box for the Rolling Stone entry (e.g. "4/5 stars" -> "****"). If the article has NO Rolling Stone rating, return "*****" (these are Rolling Stone Top 500 albums).
 - albumsSold: total copies sold worldwide as an integer if the article states a sales figure or certification-derived number; otherwise 0.
 
 Do not include albumName, artist, or genre — those are provided separately and are authoritative.`;
@@ -46,6 +47,32 @@ Do not include albumName, artist, or genre — those are provided separately and
 function buildYouTubeSearchURL(albumName, artist) {
     const q = encodeURIComponent(`${artist} ${albumName} full album`);
     return `https://www.youtube.com/results?search_query=${q}`;
+}
+
+// Resolves a real /watch?v= URL via the YouTube Data API v3 so the link embeds in
+// the RecordPage iframe (a /results search URL does not). Falls back to the search
+// URL when the key is missing or the call fails, so import never breaks on YouTube.
+// Quota: search.list costs 100 units; the daily cron imports <=3 albums, well under
+// the 10k/day free quota.
+async function resolveYouTubeURL(albumName, artist) {
+    const key = process.env.YOUTUBE_API_KEY;
+    if (!key) return buildYouTubeSearchURL(albumName, artist);
+    try {
+        const params = new URLSearchParams({
+            key,
+            part: 'snippet',
+            type: 'video',
+            maxResults: '1',
+            q: `${artist} ${albumName} full album`,
+        });
+        const res = await fetch(`https://www.googleapis.com/youtube/v3/search?${params}`);
+        if (!res.ok) return buildYouTubeSearchURL(albumName, artist);
+        const data = await res.json();
+        const id = data?.items?.[0]?.id?.videoId;
+        return id ? `https://www.youtube.com/watch?v=${id}` : buildYouTubeSearchURL(albumName, artist);
+    } catch {
+        return buildYouTubeSearchURL(albumName, artist);
+    }
 }
 
 // candidate: { albumName, artist, genre } from the CSV
@@ -69,8 +96,9 @@ async function enrichAlbum(candidate, article) {
     const text = response.content.find((b) => b.type === 'text')?.text ?? '{}';
     const derived = JSON.parse(text);
 
-    // Enforce the star format defensively (default to "*" if the model strays).
-    if (!/^\*{1,5}$/.test(derived.rollingStoneReview)) derived.rollingStoneReview = '*';
+    // Enforce the star format defensively. These are Rolling Stone Top 500 albums,
+    // so default to a perfect rating if the model strays from the star format.
+    if (!/^\*{1,5}$/.test(derived.rollingStoneReview)) derived.rollingStoneReview = '*****';
 
     return {
         // Authoritative fields from the CSV
@@ -86,7 +114,7 @@ async function enrichAlbum(candidate, article) {
         albumsSold: Math.max(0, Math.trunc(derived.albumsSold ?? 0)),
         // Constructed / sourced
         imgURL: article.imgURL,
-        youTubeAlbumURL: buildYouTubeSearchURL(candidate.albumName, candidate.artist),
+        youTubeAlbumURL: await resolveYouTubeURL(candidate.albumName, candidate.artist),
     };
 }
 

--- a/api/index.js
+++ b/api/index.js
@@ -85,8 +85,15 @@ app.get('/api/v1/users/me', checkJwt, async (req, res) => {
     try {
         const email = getAuthEmail(req);
         if (!email) return res.status(400).json({ error: 'Authenticated email required.' });
-        const user = await database('users').where('email', email).select('role').first();
-        if (!user) return res.status(404).json({ error: 'User not found.' });
+        // Auto-provision on first authenticated request: the user exists in Auth0
+        // but may not have a row here yet. Create one (role defaults to 'user');
+        // ADMIN_EMAILS still elevates via resolveRole below.
+        let user = await database('users').where('email', email).first();
+        if (!user) {
+            [user] = await database('users')
+                .insert({ email, username: email.split('@')[0], mystack: [] })
+                .returning('*');
+        }
         res.status(200).json({ role: resolveRole(email, user.role) });
     } catch (error) {
         res.status(500).json({ error: error.message });
@@ -286,14 +293,19 @@ app.patch('/albums/:id', checkJwt, async (req, res) => {
             return res.status(404).json({ error: `Album with id ${albumId} not found.` });
         }
 
+        const email = getAuthEmail(req);
         const user = await database('users')
-            .where('email', req.auth?.payload?.email)
+            .where('email', email)
             .first();
         if (!user) {
             return res.status(404).json({ error: 'User not found.' });
         }
 
-        const allowed = canPerformAction(user.role, PERMISSIONS.EDIT_ALBUM, album.created_by, req.auth.sub);
+        // Resolve the effective role so ADMIN_EMAILS elevation applies here too (the
+        // raw DB role is just the auto-created 'user' default). Identity for the
+        // ownership check is the JWT sub, which lives under req.auth.payload.sub.
+        const role = resolveRole(email, user.role);
+        const allowed = canPerformAction(role, PERMISSIONS.EDIT_ALBUM, album.created_by, req.auth?.payload?.sub);
         if (!allowed) {
             return res.status(403).json({ error: 'Insufficient permissions.' });
         }
@@ -316,14 +328,19 @@ app.delete('/albums/:id', checkJwt, async (req, res) => {
             return res.status(404).json({ error: `Album with id ${albumId} not found.` });
         }
 
+        const email = getAuthEmail(req);
         const user = await database('users')
-            .where('email', req.auth?.payload?.email)
+            .where('email', email)
             .first();
         if (!user) {
             return res.status(404).json({ error: 'User not found.' });
         }
 
-        const allowed = canPerformAction(user.role, PERMISSIONS.DELETE_ALBUM, album.created_by, req.auth.sub);
+        // Resolve the effective role so ADMIN_EMAILS elevation applies here too (the
+        // raw DB role is just the auto-created 'user' default). Identity for the
+        // ownership check is the JWT sub, which lives under req.auth.payload.sub.
+        const role = resolveRole(email, user.role);
+        const allowed = canPerformAction(role, PERMISSIONS.DELETE_ALBUM, album.created_by, req.auth?.payload?.sub);
         if (!allowed) {
             return res.status(403).json({ error: 'Insufficient permissions.' });
         }

--- a/api/wikipedia.js
+++ b/api/wikipedia.js
@@ -53,25 +53,89 @@ async function resolveImageURL(filename) {
     return data?.query?.pages?.[0]?.imageinfo?.[0]?.url ?? null;
 }
 
-// Finds the best-matching Wikipedia page title for an album. We bias the query
-// toward album articles by appending "album" and the artist name.
-async function searchPageTitle(albumName, artist) {
+// Finds candidate Wikipedia page titles for an album. We bias the query toward
+// album articles by appending "album" and the artist name, but return several
+// candidates so fetchAlbumArticle can skip non-album hits (e.g. a same-named song).
+async function searchPageTitles(albumName, artist) {
     const data = await wikiGet({
         action: 'query',
         list: 'search',
         srsearch: `${albumName} ${artist} album`,
-        srlimit: '1',
+        srlimit: '8',
         srnamespace: '0',
     });
-    return data?.query?.search?.[0]?.title ?? null;
+    return (data?.query?.search ?? []).map((r) => r.title);
 }
 
-// Fetches an album's article. Returns wikitext + cover image, or null if no page
-// is found so the caller can move on to the next album in the list.
-async function fetchAlbumArticle({ albumName, artist }) {
-    const title = await searchPageTitle(albumName, artist);
-    if (!title) return null;
+// Wikipedia's canonical disambiguation patterns for an album. Search relevance often
+// buries the original album under same-named songs/films/reissues (e.g. the plain
+// "Sgt. Pepper's Lonely Hearts Club Band" page is not even in the top search hits),
+// so we probe these exact titles directly and let scoring pick the best.
+function directTitleGuesses(albumName, artist) {
+    return [
+        albumName,
+        `${albumName} (album)`,
+        `${albumName} (${artist} album)`,
+    ];
+}
 
+// Titles that are clearly not the album article — a same-named song/single/film/EP
+// would otherwise yield the wrong cover and ratings (e.g. the "Sgt. Pepper's ...
+// (song)" page, whose cover is the single sleeve, not the album art).
+const NON_ALBUM_TITLE = /\((song|single|film|EP)\)$/i;
+
+// True when the wikitext is an album article (has an {{Infobox album}} template).
+const isAlbumArticle = (wikitext) => /\{\{\s*Infobox album/i.test(wikitext);
+
+// Loose name normalization for comparing artist names across infobox/CSV: drop
+// wikilinks/punctuation and a leading "The" so "[[The Beatles]]" == "Beatles".
+function normalizeName(s) {
+    return (s || '')
+        .toLowerCase()
+        .replace(/\[\[|\]\]/g, '')
+        .replace(/^the\s+/, '')
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim();
+}
+
+// Pulls the {{Infobox album}} artist so we can pick the page by the right artist —
+// e.g. distinguish the Beatles' "Sgt. Pepper's..." from the 1978 film soundtrack of
+// the same name (an album article too, but by various artists).
+function extractInfoboxArtist(wikitext) {
+    const m = wikitext.match(/\|\s*[Aa]rtist\s*=\s*([^\n|]+)/);
+    return m ? normalizeName(m[1].split('|').pop()) : '';
+}
+
+// True when the article's infobox artist matches the CSV artist (either contains
+// the other, after normalization), tolerating "feat."/extra words on either side.
+function artistMatches(wikitext, artist) {
+    const want = normalizeName(artist);
+    const have = extractInfoboxArtist(wikitext);
+    if (!want || !have) return false;
+    return have.includes(want) || want.includes(have);
+}
+
+// Reissue/edition markers — used to deprioritize "...: 50th Anniversary Edition",
+// deluxe/remaster pages in favor of the original album of the same name.
+const REISSUE_TITLE = /anniversary|deluxe|edition|remaster|reissue|expanded|super/i;
+
+// Scores how well a candidate page matches the album we're importing. Higher is
+// better. Artist match dominates; an exact title match beats a prefix match; and
+// reissue/edition pages are penalized so the original album wins ties.
+function scoreCandidate(title, wikitext, albumName, artist) {
+    let score = 0;
+    if (artistMatches(wikitext, artist)) score += 100;
+    const t = normalizeName(title.replace(/\s*\([^)]*\)\s*$/, '')); // drop trailing "(album)" etc.
+    const a = normalizeName(albumName);
+    if (t === a) score += 30;
+    else if (t.startsWith(a)) score += 10;
+    else if (t.includes(a)) score += 5;
+    if (REISSUE_TITLE.test(title)) score -= 15;
+    return score;
+}
+
+// Fetches one page's wikitext + lead image. Returns null if missing/empty.
+async function fetchPageData(title) {
     const pageData = await wikiGet({
         action: 'query',
         titles: title,
@@ -82,21 +146,45 @@ async function fetchAlbumArticle({ albumName, artist }) {
     });
     const page = pageData?.query?.pages?.[0];
     if (!page || page.missing) return null;
+    const wikitext = page.revisions?.[0]?.slots?.main?.content ?? '';
+    if (!wikitext) return null;
+    return { wikitext, leadImage: page.original?.source ?? null };
+}
 
-    const fullWikitext = page.revisions?.[0]?.slots?.main?.content ?? '';
-    if (!fullWikitext) return null;
-
+// Builds the article result (resolves the cover image) for a chosen page.
+async function buildArticle(title, page) {
     // Prefer the infobox cover (album covers are non-free, so PageImages omits them);
     // fall back to the PageImages lead image if the article has no infobox cover.
-    const coverFilename = extractCoverFilename(fullWikitext);
-    const imgURL = (coverFilename && await resolveImageURL(coverFilename)) || page.original?.source || null;
-
+    const coverFilename = extractCoverFilename(page.wikitext);
+    const imgURL = (coverFilename && await resolveImageURL(coverFilename)) || page.leadImage || null;
     return {
         matchedTitle: title,
-        wikitext: fullWikitext.slice(0, MAX_WIKITEXT_CHARS),
+        wikitext: page.wikitext.slice(0, MAX_WIKITEXT_CHARS),
         imgURL,
         sourceUrl: `https://en.wikipedia.org/wiki/${encodeURIComponent(title.replace(/ /g, '_'))}`,
     };
+}
+
+// Fetches an album's article. Of the search candidates that are album articles
+// ({{Infobox album}}), picks the best-scoring one (see scoreCandidate): same artist,
+// exact title, original over reissue. This skips same-named songs/singles, same-named
+// albums by other artists (e.g. the 1978 "Sgt. Pepper's..." film soundtrack), and
+// anniversary/deluxe editions. Returns null if no album page is found.
+async function fetchAlbumArticle({ albumName, artist }) {
+    const searched = await searchPageTitles(albumName, artist);
+    // Probe canonical exact titles first, then search hits; dedupe and drop obvious
+    // song/single pages. The exact-title probes rescue albums the search buries.
+    const candidates = [...new Set([...directTitleGuesses(albumName, artist), ...searched])]
+        .filter((t) => !NON_ALBUM_TITLE.test(t));
+
+    let best = null; // { title, page, score }
+    for (const title of candidates) {
+        const page = await fetchPageData(title);
+        if (!page || !isAlbumArticle(page.wikitext)) continue;
+        const score = scoreCandidate(title, page.wikitext, albumName, artist);
+        if (!best || score > best.score) best = { title, page, score };
+    }
+    return best ? buildArticle(best.title, best.page) : null;
 }
 
 module.exports = { fetchAlbumArticle };


### PR DESCRIPTION
# Branch: `fix/youTube-url-wikipedia-imgUrl`

Bug-fix branch addressing four issues found after the Auth0 flow and the daily
album-import cron went live. Changes touch three files: `api/index.js`,
`api/wikipedia.js`, and `api/enrich.js` (plus a new `YOUTUBE_API_KEY` env var).

## Commits

| Commit | Summary |
| --- | --- |
| `060b60b` | Refactor wiki methods to return accurate album URLs; YouTube Data API v3 for iframe-embeddable URLs |
| `900949b` | API search methods for accurate album lookup |
| `d384dd1` | Resolve album ownership / permissions check |

---

## 1. `/api/v1/users/me` returned 404 for authenticated users

**File:** `api/index.js`

A user authenticated via Auth0 (valid JWT, `email` claim present) got a 404 from
`/me` because nothing in the codebase ever created a `users` row — the user existed
in Auth0 but not in our database. (The `/token` 200 the client saw is Auth0's own
`/oauth/token` endpoint, unrelated to our DB.)

**Fix:** `/me` now auto-provisions the user on first authenticated request
(select-then-insert; the `users.email` column has no unique constraint, so an
`onConflict` upsert isn't available). The row defaults to role `user`; admin status
is still applied at read time via `resolveRole` + the `ADMIN_EMAILS` env var.

## 2. Wrong album cover from the cron

**File:** `api/wikipedia.js`

Root cause was **page selection**, not the image field. The import's Wikipedia search
(`"<album> <artist> album"`) returned the *song* article for Sgt. Pepper's (cover
`Smsgtpep.jpg`) instead of the album article. The original album page is often buried
in search relevance under same-named songs, films, soundtracks, and reissues — for
Sgt. Pepper's the plain-titled album page wasn't even in the top results.

**Fix:** rewrote `fetchAlbumArticle` to select the correct page deterministically:

- `searchPageTitles` returns up to **8** candidates (was top-1).
- `directTitleGuesses` probes Wikipedia's canonical exact titles directly
  (`<album>`, `<album> (album)`, `<album> (<artist> album)`) — this rescues albums
  the search buries.
- Candidates are filtered to actual album articles (`{{Infobox album}}`), with
  obvious `(song)/(single)/(film)/(EP)` titles dropped up front.
- `scoreCandidate` ranks the rest: infobox-**artist match dominates** (distinguishes
  the Beatles album from the 1978 film soundtrack of the same name), **exact title**
  beats a prefix match, and **reissue/edition** pages (anniversary/deluxe/remaster…)
  are penalized so the original album wins ties.

Once the right page is chosen, the existing infobox-cover extraction already returns
the correct image. Verified across Sgt. Pepper's, Rumours, Thriller, Pet Sounds,
Blue, Abbey Road, and Purple Rain — Sgt. Pepper's now resolves to
`.../commons/5/57/Sgt._Pepper%27s_Lonely_Hearts_Club_Band_album_art.jpg`.

## 3. Rolling Stone rating default

**File:** `api/enrich.js`

Default rating changed from `*` to `*****` in both the extraction prompt and the
defensive fallback, since these are Rolling Stone Top 500 albums.

## 4. YouTube URL wasn't iframe-embeddable

**File:** `api/enrich.js`

The import stored a YouTube **search** URL (`youtube.com/results?search_query=...`),
which won't embed in the RecordPage iframe.

**Fix:** new `resolveYouTubeURL` calls the **YouTube Data API v3** `search.list` and
returns a real `watch?v=<id>` URL. It **falls back** to the old search URL when
`YOUTUBE_API_KEY` is missing or the call fails, so imports never break on YouTube.
Quota is negligible (100 units/search × ≤3 albums/day, vs. 10k/day free).

## 5. PATCH/DELETE `/albums/:id` returned 403 for admins

**File:** `api/index.js`

Editing the cron's first album returned `403 Insufficient permissions` even though
`/me` reported `admin`. Two compounding bugs in both handlers:

1. They passed the **raw DB role** (`user.role`, i.e. the auto-created `user`
   default) to `canPerformAction` instead of `resolveRole(email, user.role)`, so the
   `ADMIN_EMAILS` admin elevation that `/me` applies was ignored here.
2. The ownership check read `req.auth.sub`, which is **`undefined`** — the JWT claims
   live under `req.auth.payload.sub` — making `album.created_by === undefined` always
   false.

**Fix:** both handlers now resolve the effective role via `resolveRole`, read the sub
from `req.auth?.payload?.sub`, and use the shared `getAuthEmail(req)` helper. Admins
can now edit/delete any album, and the ownership check works for cron-created albums
(whose `created_by` equals the importer's `sub`).

---

## Config / deployment notes (not in code)

- **`ADMIN_EMAILS`** must be set in the **Vercel production** environment (e.g.
  `kylemboomer@gmail.com`). It exists locally; without it in production, `/me` returns
  `user` and the permission fixes above won't elevate you to admin.
- **`YOUTUBE_API_KEY`** must be provisioned in Google Cloud (enable "YouTube Data API
  v3") and added to `.env` / Vercel. Without it, the import gracefully falls back to a
  YouTube search URL.

## Verification

- `node api/wikipedia.js "<album>" "<artist>"` prints the matched title + resolved
  `imgURL` (used to confirm correct album-page selection).
- After deploy: `GET /api/v1/users/me` with a valid token returns `200` and creates
  the row; `PATCH /albums/:id` returns `200` for an admin.
