### PR TITLE
Feat/improve filtering sorting pagination

### DIFF
--- a/api/genres.js
+++ b/api/genres.js
@@ -1,0 +1,104 @@
+// Canonical genre taxonomy + a parser that turns the raw `genre` string into the
+// set of canonical genres an album belongs to.
+//
+// Why this exists: the Rolling Stone CSV (the cron's source) stores genre as a
+// Discogs-style list joined with ", " — e.g. "Electronic, Rock" or
+// "Rock, Funk / Soul". The trap is that several *canonical* genres contain commas
+// themselves ("Folk, World, & Country", "Funk / Soul", "Stage & Screen"), so a
+// naive split(',') shreds them. Instead we match known canonical names out of the
+// raw string, longest-first, so the multi-word names win before their fragments.
+//
+// This is the single source of truth for what genres exist. To add/rename a genre,
+// edit CANONICAL_GENRES (and GENRE_ALIASES for legacy spellings) — nothing else.
+
+// Order matters only for readability; matching sorts by length internally.
+const CANONICAL_GENRES = [
+    'Rock',
+    'Pop',
+    'Hip Hop',
+    'Electronic',
+    'Funk / Soul',
+    'Jazz',
+    'Blues',
+    'Reggae',
+    'Latin',
+    'Classical',
+    'Folk, World, & Country',
+    'Stage & Screen',
+];
+
+// Legacy / variant spellings → canonical name. Seed data used single-genre strings
+// like "Hip-Hop", "Folk", "Country"; these fold them into the canonical buckets so
+// old and new rows land in the same genre. Keys are matched case-insensitively.
+const GENRE_ALIASES = {
+    'hip-hop': 'Hip Hop',
+    'hiphop': 'Hip Hop',
+    'rap': 'Hip Hop',
+    'r&b': 'Funk / Soul',
+    'funk': 'Funk / Soul',
+    'soul': 'Funk / Soul',
+    'folk': 'Folk, World, & Country',
+    'country': 'Folk, World, & Country',
+    'world': 'Folk, World, & Country',
+};
+
+const escapeRegExp = (s) => s.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&');
+
+// One alternation of every canonical name and alias, sorted longest-first so
+// "Folk, World, & Country" is consumed before the bare "Folk" alias or a stray
+// "Country", and "Funk / Soul" before "Funk"/"Soul". Each match maps back to its
+// canonical name. Global + case-insensitive; a matched span is not re-scanned, so
+// fragments inside a longer match can't double-count.
+const MATCHERS = [
+    ...CANONICAL_GENRES.map((name) => ({ pattern: name, canonical: name })),
+    ...Object.entries(GENRE_ALIASES).map(([alias, canonical]) => ({ pattern: alias, canonical })),
+].sort((a, b) => b.pattern.length - a.pattern.length);
+
+const lookup = new Map(MATCHERS.map((m) => [m.pattern.toLowerCase(), m.canonical]));
+const GENRE_REGEX = new RegExp(MATCHERS.map((m) => escapeRegExp(m.pattern)).join('|'), 'gi');
+
+// Case-insensitive index of every canonical/alias spelling -> canonical display name,
+// used by canonicalizeName to fold known variants ("hip-hop" -> "Hip Hop").
+const CANONICAL_BY_LOWER = new Map([
+    ...CANONICAL_GENRES.map((name) => [name.toLowerCase(), name]),
+    ...Object.entries(GENRE_ALIASES).map(([alias, canonical]) => [alias.toLowerCase(), canonical]),
+]);
+
+// Normalizes a SINGLE, already-discrete genre name (one a user picked/typed — NOT a
+// compound CSV string; use parseGenres for those). Collapses whitespace incl. U+00A0,
+// trims, and folds known canonical/alias spellings to their canonical display form.
+// An unrecognized name is returned cleaned-but-verbatim so user genres are preserved.
+function canonicalizeName(raw) {
+    if (!raw || typeof raw !== 'string') return '';
+    const cleaned = raw.replace(/\s+/g, ' ').trim();
+    return CANONICAL_BY_LOWER.get(cleaned.toLowerCase()) || cleaned;
+}
+
+// Stable, case-insensitive dedupe key for a genre. Two spellings that canonicalize to
+// the same name (e.g. "Shoegaze"/" shoegaze ", "Hip-Hop"/"Hip Hop") share one slug.
+function genreSlug(raw) {
+    return canonicalizeName(raw).toLowerCase();
+}
+
+// raw: the album's `genre` column value, possibly null/empty.
+// Returns an ordered, de-duplicated array of canonical genre names. Unknown text
+// yields []; callers decide how to handle an album with no recognized genre.
+function parseGenres(raw) {
+    if (!raw || typeof raw !== 'string') return [];
+    // Collapse all whitespace runs to single spaces. JS \s includes the U+00A0
+    // non-breaking spaces the CSV is littered with, so this normalizes them too.
+    const normalized = raw.replace(/\s+/g, ' ').trim();
+
+    const seen = new Set();
+    const out = [];
+    for (const match of normalized.matchAll(GENRE_REGEX)) {
+        const canonical = lookup.get(match[0].toLowerCase());
+        if (canonical && !seen.has(canonical)) {
+            seen.add(canonical);
+            out.push(canonical);
+        }
+    }
+    return out;
+}
+
+module.exports = { CANONICAL_GENRES, GENRE_ALIASES, parseGenres, canonicalizeName, genreSlug };

--- a/api/index.js
+++ b/api/index.js
@@ -13,6 +13,39 @@ const { randomUUID } = require('node:crypto');
 const { loadAlbumList } = require('./albumList');
 const { fetchAlbumArticle } = require('./wikipedia');
 const { enrichAlbum } = require('./enrich');
+const { parseGenres, canonicalizeName, genreSlug } = require('./genres');
+
+// Sets an album's genres from a list of already-discrete genre names and (re)writes
+// the album_genres links. This is the create-or-attach core: each name is normalized
+// and matched by slug to an existing genre, or inserted as a NEW user-contributed
+// genre (is_canonical defaults to false). Idempotent — it clears the album's existing
+// links and inserts the current set, so it's safe on both create and update.
+//
+// Callers supply discrete names: user submissions pass their genres[] array (one
+// genre per element); the cron passes parseGenres(rawString) to split the compound
+// Discogs CSV string first. Never run a compound string through here directly.
+const setAlbumGenres = async (albumId, names) => {
+    // Normalize + dedupe by slug so "Shoegaze"/"shoegaze" collapse to one genre.
+    const bySlug = new Map();
+    for (const raw of names || []) {
+        const slug = genreSlug(raw);
+        if (slug && !bySlug.has(slug)) bySlug.set(slug, canonicalizeName(raw));
+    }
+
+    await database('album_genres').where('album_id', albumId).del();
+    if (bySlug.size === 0) return;
+
+    const slugs = [...bySlug.keys()];
+    // Insert any genres we don't have yet (existing canonical rows are untouched, so
+    // they keep is_canonical = true), then read back ids for every slug we need.
+    await database('genres')
+        .insert(slugs.map(slug => ({ name: bySlug.get(slug), slug })))
+        .onConflict('slug').ignore();
+    const rows = await database('genres').whereIn('slug', slugs).select('id');
+    await database('album_genres')
+        .insert(rows.map(r => ({ album_id: albumId, genre_id: r.id })))
+        .onConflict(['album_id', 'genre_id']).ignore();
+};
 
 database.on('query', queryData => {
     console.log('SQL:', queryData.sql);
@@ -104,37 +137,52 @@ app.get('/api/v1/users/me', checkJwt, async (req, res) => {
 // arbitrary req.query values from reaching .orderBy()/.where() as identifiers.
 // releaseDate is intentionally omitted from SORTABLE: it's stored as a string
 // (e.g. "September 12th, 1975"), so it would sort alphabetically, not by date.
-const ALBUM_SORTABLE = ['albumName', 'artist', 'genre', 'albumsSold', 'created_at'];
-const ALBUM_FILTERABLE = ['genre', 'artist', 'label', 'isBandTogether'];
+// rollingStoneReview IS sortable: it's stored as asterisks ("*".."*****"), and
+// because each rating is a prefix of the next, lexicographic order matches star
+// count (asc = 1 star first, desc = 5 stars first).
+const ALBUM_SORTABLE = ['albumName', 'artist', 'albumsSold', 'created_at', 'rollingStoneReview'];
+// `genre` is handled separately via the album_genres join, not as a column filter.
+const ALBUM_FILTERABLE = ['artist', 'label', 'isBandTogether'];
 
 app.get('/albums', async (request, res) => {
 
     try {
-        const { sortBy, order, search, ...filters } = request.query;
+        const { sortBy, order, search, genre, ...filters } = request.query;
         let query = database('albums');
 
-        // Exact-match filters, e.g. ?genre=Rock&artist=Pink Floyd
+        // Genre now lives in the join table, so ?genre=Rock filters via album_genres
+        // against the canonical genre name. Columns are qualified because the join
+        // brings ambiguous names (genres.name etc.) into scope.
+        if (genre) {
+            query = query
+                .join('album_genres', 'albums.id', 'album_genres.album_id')
+                .join('genres', 'genres.id', 'album_genres.genre_id')
+                .where('genres.name', genre);
+        }
+
+        // Exact-match filters, e.g. ?artist=Pink Floyd
         for (const [key, value] of Object.entries(filters)) {
             if (ALBUM_FILTERABLE.includes(key)) {
-                query = query.where(key, value);
+                query = query.where(`albums.${key}`, value);
             }
         }
 
         // Case-insensitive free-text search across name + artist, e.g. ?search=floyd
         if (search) {
             query = query.where(builder =>
-                builder.whereILike('albumName', `%${search}%`)
-                    .orWhereILike('artist', `%${search}%`)
+                builder.whereILike('albums.albumName', `%${search}%`)
+                    .orWhereILike('albums.artist', `%${search}%`)
             );
         }
 
         // Sorting, e.g. ?sortBy=albumsSold&order=desc
         if (sortBy && ALBUM_SORTABLE.includes(sortBy)) {
             const dir = order === 'desc' ? 'desc' : 'asc';
-            query = query.orderBy(sortBy, dir);
+            query = query.orderBy(`albums.${sortBy}`, dir);
         }
 
-        const albums = await query.select()
+        // Select only album columns so the join tables don't leak into the response.
+        const albums = await query.select('albums.*')
         res.status(200).json(albums)
     } catch (error) {
         console.error('Database error:', error)
@@ -159,14 +207,20 @@ app.get('/albums/:id', async (req, res) => {
     }
 });
 
+// Genres that have at least one album, for filter/search UIs. Returns objects
+// { name, isCanonical } so the client can segment the curated taxonomy from
+// user-contributed genres. ?canonical=true narrows to the canonical set only.
 app.get('/api/v1/genres', async (req, res) => {
     try {
-        const genres = await database('albums')
-            .distinct('genre')
-            .whereNotNull('genre')
-            .orderBy('genre', 'asc')
-            .pluck('genre');
-        res.status(200).json(genres);
+        let query = database('genres')
+            .join('album_genres', 'genres.id', 'album_genres.genre_id')
+            .distinct('genres.name', 'genres.is_canonical')
+            .orderBy('genres.name', 'asc');
+        if (req.query.canonical === 'true') {
+            query = query.where('genres.is_canonical', true);
+        }
+        const rows = await query.select();
+        res.status(200).json(rows.map(r => ({ name: r.name, isCanonical: r.is_canonical })));
     } catch (error) {
         console.error('Error fetching genres:', error);
         res.status(500).json({ error: error.message });
@@ -180,23 +234,35 @@ app.get('/api/v1/genres', async (req, res) => {
 app.get('/api/v1/albums/by-genre', async (req, res) => {
     const limit = Math.min(parseInt(req.query.limit) || 20, 50);
     try {
+        // Top-N albums per canonical genre, capped in SQL via a window over the
+        // album_genres join. Restricted to is_canonical genres so user-contributed
+        // genres never auto-promote into homepage carousels (they stay filterable via
+        // /albums?genre=X). An album with multiple genres appears in each of its
+        // canonical genre groups. `genre_name` is the canonical name; the row also
+        // still carries the album's legacy `genre` string from albums.*.
         const ranked = await database
             .with('ranked', database.raw(
-                `SELECT *, ROW_NUMBER() OVER (PARTITION BY genre ORDER BY "albumName" ASC) AS rn
-                 FROM albums WHERE genre IS NOT NULL`))
+                `SELECT a.*, g.name AS genre_name,
+                        ROW_NUMBER() OVER (PARTITION BY g.id ORDER BY a."albumName" ASC) AS rn
+                 FROM albums a
+                 JOIN album_genres ag ON ag.album_id = a.id
+                 JOIN genres g ON g.id = ag.genre_id
+                 WHERE g.is_canonical = true`))
             .select('*').from('ranked').where('rn', '<=', limit)
-            .orderBy(['genre', 'albumName']);
+            .orderBy(['genre_name', 'albumName']);
 
         const byGenre = new Map();
         const grouped = [];
         for (const row of ranked) {
-            if (!byGenre.has(row.genre)) {
-                const entry = { genre: row.genre, albums: [] };
-                byGenre.set(row.genre, entry);
+            const genreName = row.genre_name;
+            if (!byGenre.has(genreName)) {
+                const entry = { genre: genreName, albums: [] };
+                byGenre.set(genreName, entry);
                 grouped.push(entry);
             }
             delete row.rn;
-            byGenre.get(row.genre).albums.push(row);
+            delete row.genre_name;
+            byGenre.get(genreName).albums.push(row);
         }
         res.status(200).json(grouped);
     } catch (error) {
@@ -214,9 +280,17 @@ app.post('/add-stack', checkJwt, requirePermission('create_album'), async (req, 
         return res.status(400).json({ error: message })
     }
     try {
+        // `genres` is a virtual field (no such column) — pull it out before insert.
+        // A user submission carries genres[]; fall back to the single `genre` string.
+        const { genres, ...albumData } = result.data;
+        const genreNames = genres?.length ? genres : (albumData.genre ? [albumData.genre] : []);
+        // Keep the legacy `genre` column populated for back-compat / human reference.
+        if (!albumData.genre) albumData.genre = genreNames.map(canonicalizeName).join(', ');
+
         const postedAlbum = await database('albums')
-            .insert({ ...result.data, id: randomUUID(), created_by: req.auth.sub })
+            .insert({ ...albumData, id: randomUUID(), created_by: req.auth.sub })
             .returning('*')
+        await setAlbumGenres(postedAlbum[0].id, genreNames)
         res.status(201).json(postedAlbum[0])
     } catch (error) {
         console.error('Error posting your record :(', error)
@@ -272,6 +346,8 @@ app.get('/api/cron/import-albums', async (req, res) => {
             const [inserted] = await database('albums')
                 .insert({ ...result.data, id: randomUUID(), created_by: process.env.CRON_AUTHOR_SUB })
                 .returning('*');
+            // Cron genre is one compound Discogs string — split it before linking.
+            await setAlbumGenres(inserted.id, parseGenres(inserted.genre));
             return res.status(201).json({ added: inserted.albumName, rank: candidate.rank, skipped });
         }
 
@@ -310,10 +386,18 @@ app.patch('/albums/:id', checkJwt, async (req, res) => {
             return res.status(403).json({ error: 'Insufficient permissions.' });
         }
 
+        // `genres` is virtual (no column) — keep it out of the column update and use
+        // it to re-link instead. `genre` (single string) edits also re-sync the links.
+        const { genres, ...columnUpdates } = updates;
         const updated = await database('albums')
             .where('id', albumId)
-            .update({ ...updates, updated_at: new Date() })
+            .update({ ...columnUpdates, updated_at: new Date() })
             .returning('*');
+        if (genres?.length) {
+            await setAlbumGenres(albumId, genres);
+        } else if (Object.prototype.hasOwnProperty.call(updates, 'genre')) {
+            await setAlbumGenres(albumId, updated[0].genre ? [updated[0].genre] : []);
+        }
         res.status(200).json(updated[0]);
     } catch (error) {
         res.status(500).json({ error: error.message });

--- a/api/validation.js
+++ b/api/validation.js
@@ -23,7 +23,11 @@ const albumSchema = z.object({
     albumName: z.string().min(1, 'albumName is required'),
     artist: z.string().min(1, 'artist is required'),
     releaseDate: z.string().min(1, 'releaseDate is required'),
-    genre: z.string().min(1, 'genre is required'),
+    // Genre may arrive two ways: a single string (cron's compound Discogs value) or
+    // a genres[] array (user multi-select). Both optional here; the refine below
+    // requires at least one. Array entries are capped to curb sprawl/abuse.
+    genre: z.string().min(1).optional(),
+    genres: z.array(z.string().trim().min(1).max(50)).max(10).optional(),
     label: z.string().min(1, 'label is required'),
     bandMembers: z.array(z.string().min(1)).min(1, 'bandMembers is required'),
     isBandTogether: z.boolean(),
@@ -33,6 +37,9 @@ const albumSchema = z.object({
         .refine(isHttpURL, 'youTubeAlbumURL must be a valid URL')
         .refine(isYouTubeURL, 'youTubeAlbumURL must be a YouTube link'),
     imgURL: z.string().refine(isHttpURL, 'imgURL must be a valid http(s) URL'),
-});
+}).refine(
+    (data) => Boolean(data.genre) || (data.genres?.length ?? 0) > 0,
+    { message: 'at least one genre is required (genre or genres[])', path: ['genre'] }
+);
 
 module.exports = { albumSchema };

--- a/knex/migrations/20260610120000_create_genres.js
+++ b/knex/migrations/20260610120000_create_genres.js
@@ -1,0 +1,89 @@
+// Normalizes genre from a free-text column on `albums` into a first-class entity
+// with a many-to-many link, so the landing page can drive carousels off a finite,
+// canonical genre set instead of the ever-growing tangle of raw genre strings the
+// daily cron produces (e.g. "Electronic, Rock", "Folk, World, & Country").
+//
+// Three steps, in order:
+//   1. Ensure albums.id is uniquely constrained (it was created as a bare string),
+//      so album_genres.album_id can reference it.
+//   2. Create `genres` and the `album_genres` join table.
+//   3. Seed the canonical genres and backfill links by parsing each album's existing
+//      genre string. The legacy albums.genre column is left in place as the source
+//      of truth for re-runs and as a fallback; it is no longer read by the app.
+
+const { CANONICAL_GENRES, parseGenres, genreSlug } = require('../../api/genres');
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+    // 1. albums.id needs a unique constraint to be referenceable by a FK. It was
+    //    created as a plain string column with no key. Use a unique index (named so
+    //    the down migration can drop it) rather than a PK to avoid clashing with any
+    //    implicit key Postgres/knex may have added.
+    const hasUnique = await knex.raw(
+        `SELECT 1 FROM pg_constraint WHERE conname = 'albums_id_unique'`
+    );
+    if (hasUnique.rows.length === 0) {
+        await knex.schema.alterTable('albums', (table) => {
+            table.unique(['id'], { indexName: 'albums_id_unique' });
+        });
+    }
+
+    // 2. Canonical genres, and the album↔genre join.
+    await knex.schema.createTable('genres', (table) => {
+        table.increments('id').primary();
+        table.string('name').notNullable().unique();
+        // Case-insensitive dedupe key (lowercased, alias-resolved). User-submitted
+        // spellings fold onto an existing genre when their slug already exists.
+        table.string('slug').notNullable().unique();
+        // Distinguishes the curated Top-500 taxonomy from genres users contribute.
+        // Only canonical genres drive landing-page carousels; user genres stay
+        // filterable/searchable. Defaults to false so user inserts are user genres.
+        table.boolean('is_canonical').notNullable().defaultTo(false);
+        table.timestamp('created_at').defaultTo(knex.fn.now());
+    });
+
+    await knex.schema.createTable('album_genres', (table) => {
+        table.string('album_id').notNullable()
+            .references('id').inTable('albums').onDelete('CASCADE');
+        table.integer('genre_id').notNullable()
+            .references('id').inTable('genres').onDelete('CASCADE');
+        table.primary(['album_id', 'genre_id']);
+        // The landing page queries "albums in genre X", so index the genre side.
+        table.index('genre_id', 'album_genres_genre_id_index');
+    });
+
+    // 3a. Seed the canonical genre rows (flagged canonical, with their slug) and
+    //     build a name -> id map for the backfill.
+    const inserted = await knex('genres')
+        .insert(CANONICAL_GENRES.map((name) => ({ name, slug: genreSlug(name), is_canonical: true })))
+        .returning(['id', 'name']);
+    const idByName = new Map(inserted.map((g) => [g.name, g.id]));
+
+    // 3b. Backfill links from each album's existing genre string.
+    const albums = await knex('albums').select('id', 'genre');
+    const links = [];
+    for (const album of albums) {
+        for (const canonical of parseGenres(album.genre)) {
+            const genreId = idByName.get(canonical);
+            if (genreId) links.push({ album_id: album.id, genre_id: genreId });
+        }
+    }
+    if (links.length) {
+        await knex('album_genres').insert(links).onConflict(['album_id', 'genre_id']).ignore();
+    }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+    await knex.schema.dropTableIfExists('album_genres');
+    await knex.schema.dropTableIfExists('genres');
+    await knex.schema.alterTable('albums', (table) => {
+        table.dropUnique(['id'], 'albums_id_unique');
+    });
+};


### PR DESCRIPTION
# Branch: `feat/improve-filtering-sorting-pagination`

Normalizes genre from a free-text column into a first-class, many-to-many entity, and
hardens album filtering/sorting. This lets the LandingPage drive per-genre carousels off
a finite, canonical genre set instead of the ever-growing tangle of raw genre strings the
daily cron produces — while still letting users apply their own genres to albums they post.

## Why

`albums.genre` was a single free-text string. Two forces made that unsustainable:

1. **The daily cron** imports from a Rolling Stone CSV whose `genre` column is a
   Discogs-style list (`"Electronic, Rock"`, `"Rock, Funk / Soul"`) where several genres
   *contain commas themselves* (`"Folk, World, & Country"`, `"Funk / Soul"`,
   `"Stage & Screen"`). 500 rows collapsed to 63 distinct strings but only ~12 real genres,
   plus ` ` (non-breaking space) artifacts and spelling drift (`"Hip-Hop"` vs `"Hip Hop"`).
2. **User submissions** can apply any genre, which would compound the sprawl.

The result would have been an unbounded number of messy, near-duplicate carousels.

## Data model

New tables (see migration below):

- **`genres`** — `id`, `name` (display, unique), `slug` (unique, case-insensitive dedupe
  key), `is_canonical` (bool), `created_at`.
- **`album_genres`** — join table: `album_id` → `albums.id` (FK, `ON DELETE CASCADE`),
  `genre_id` → `genres.id` (FK, `ON DELETE CASCADE`), composite PK, index on `genre_id`.

`is_canonical` separates the curated ~12-genre taxonomy (drives carousels) from
user-contributed genres (filterable/searchable only). `slug` folds spelling variants onto
one row. A unique constraint was also added to `albums.id` (it had none) so it can be
referenced by the join's FK.

The legacy `albums.genre` string column is **kept** (back-compat / human reference / the
backfill source) but is no longer read by the app for display or filtering.

## Changes by file

### `api/genres.js` (new) — genre taxonomy + parsing

Single source of truth for genres. To add/rename a genre, edit `CANONICAL_GENRES`
(and `GENRE_ALIASES` for legacy spellings) — nothing else.

- `CANONICAL_GENRES` — the 12 canonical Discogs-style genres.
- `GENRE_ALIASES` — variant → canonical (`hip-hop`/`rap` → `Hip Hop`, `funk`/`soul` →
  `Funk / Soul`, `folk`/`country`/`world` → `Folk, World, & Country`, …).
- `parseGenres(raw)` — **splits a compound string** (the cron/CSV path). Matches canonical
  names out of the raw string *longest-first* so comma-containing genres survive instead of
  being shredded by a naive `split(',')`. Normalizes ` `. Tested against all 500 CSV
  rows: 0 unmatched.
- `canonicalizeName(raw)` — normalizes **one already-discrete** genre name (the user path):
  cleans whitespace/case, folds known canonical/alias spellings; preserves unknown user
  names verbatim.
- `genreSlug(raw)` — `canonicalizeName(raw).toLowerCase()`; the dedupe key.

The key distinction: `parseGenres` is for *splitting compound strings*; `canonicalizeName`
is for *normalizing discrete names*. Conflating the two was the original bug.

### `knex/migrations/20260610120000_create_genres.js` (new)

1. Add a unique constraint to `albums.id`.
2. Create `genres` and `album_genres`.
3. Seed the 12 canonical genres (`is_canonical = true`, with slugs).
4. Backfill `album_genres` by running each existing `albums.genre` through `parseGenres`.

`down` drops both tables and the unique constraint. Rollback/re-apply verified to restore
all backfilled links.

### `api/validation.js` — accept `genres[]`

`albumSchema` now accepts genre two ways: a single `genre` string (cron's compound value)
**or** a `genres` array (user multi-select, capped at 10 entries × 50 chars). A `.refine`
requires at least one of the two to be present.

### `api/index.js` — linking core + route updates

- **`setAlbumGenres(albumId, names[])`** — create-or-attach core. Normalizes + dedupes by
  slug, inserts any missing genres as user-contributed (`is_canonical` defaults `false`),
  clears the album's links and inserts the current set. Idempotent (safe on create + update).
  - `/add-stack`: pulls the virtual `genres` field out before insert; links via the
    submitted array (or `[genre]`).
  - cron import: links via `parseGenres(inserted.genre)` (split the compound string first).
  - `PATCH /albums/:id`: re-links when `genres[]` or `genre` is edited.
- **`GET /albums`** — `?genre=X` now filters through the `album_genres` join on the canonical
  name; columns are qualified and the response selects `albums.*` so join tables don't leak.
  Free-text `?search=` and `?sortBy=/order=` retained.
- **`GET /albums` sorting** — `rollingStoneReview` added to the sortable whitelist. It's
  stored as asterisks (`"*".."*****"`); since each rating is a prefix of the next,
  lexicographic order matches star count (asc = 1★ first, desc = 5★ first). `releaseDate`
  stays unsortable (stored as a free-text date string).
- **`GET /api/v1/genres`** — now reads from the `genres`/`album_genres` tables and returns
  objects `{ name, isCanonical }` for genres that have ≥1 album. `?canonical=true` narrows
  to the canonical set. **(Shape change: was a `string[]`.)**
- **`GET /api/v1/albums/by-genre`** — rewritten over the join with `WHERE g.is_canonical =
  true`, so only canonical genres become homepage carousels (user genres stay filterable but
  don't auto-promote). A multi-genre album appears in each of its canonical groups.

## Behavior summary

| Input | Result |
|---|---|
| Cron imports `"Electronic, Rock"` | Linked to canonical `Electronic` + `Rock` |
| User posts `genres: ["Shoegaze", "Rock"]` | `Rock` attaches to canonical; `Shoegaze` created as user genre |
| User posts `"shoegaze"` again | No duplicate (slug dedupe) |
| User posts `"Hip-Hop"` | Folds into canonical `Hip Hop`, no new row |
| Carousels (`by-genre`) | Canonical genres only |
| `/albums?genre=Shoegaze` | Returns the album (user genres are filterable) |

## Verification performed

- Parser: all 500 CSV genre strings resolve, 0 unmatched.
- Migration rollback + re-apply: 12 canonical genres seeded with slugs/`is_canonical`,
  all backfilled links restored.
- User-genre lifecycle (create-or-attach, slug dedupe, alias fold, canonical-only carousels,
  filterability) confirmed against the local DB.
- `albumSchema` accepts `genres[]`, accepts `genre`, rejects neither.
- `rollingStoneReview` sort order confirmed against the DB.
- `node --check` clean on all edited files.

## Notes / follow-ups

- **Frontend:** `/api/v1/genres` changed shape (`string[]` → `[{ name, isCanonical }]`); the
  submit form should send `genres: [...]` (single `genre` string still accepted).
- **Pagination** (in the branch name) is **not yet implemented** — `/albums` still returns all
  matching rows. Adding `limit`/`offset` (or cursor pagination) is the natural next step as
  the catalog grows.
- **`rollingStoneReview` data quirk:** some seed rows hold `"N/A"`/empty instead of asterisks,
  so they sort to the extremes. The cron/schema enforce asterisks going forward; a one-time
  backfill could normalize the legacy values if consistent ordering is wanted.
- **Admin affordance (future):** with an open vocabulary the `genres` table slowly accrues
  user genres; a way to promote a popular user genre to canonical (flip `is_canonical`) or
  merge near-duplicates would be useful eventually.

